### PR TITLE
Docs: Fix return object property

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Both functions return a promise which will receive the results object. The resul
     'fileOne.txt': {
         matches: ['found string'],
         count: 1,
-        lines: ['This line contains a found string.']
+        line: ['This line contains a found string.']
     }
 }
 ```


### PR DESCRIPTION
`line` is what is actually returned instead of `lines`.

If you wanted it to return `lines`, the code needs fixing (and a major version update).